### PR TITLE
 Replace `BridgeStore<Id32>` with generic `S` in `transact`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Replace `BridgeStore<Id32>` with generic `S` in `transact` [#19]
+
 ## [0.6.0] - 2021-03-01
 
 ### Added
@@ -148,6 +150,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Basic transaction framework
 
+[#19]: https://github.com/dusk-network/dusk-abi/issues/19
 [unreleased]: https://github.com/dusk-network/dusk-abi/compare/v0.6.0...HEAD
 [0.6.0]: https://github.com/dusk-network/dusk-abi/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/dusk-network/dusk-abi/compare/v0.5.0...v0.5.1

--- a/src/hosted.rs
+++ b/src/hosted.rs
@@ -125,21 +125,22 @@ pub fn transact_raw(
 ///
 /// Note that you will have to specify the expected return and argument types
 /// yourself.
-pub fn transact<A, R, Slf>(
+pub fn transact<S, A, R, Slf>(
     slf: &mut Slf,
     target: &ContractId,
     transaction: &A,
-) -> Result<R, <BridgeStore<Id32> as Store>::Error>
+) -> Result<R, S::Error>
 where
-    A: Canon<BridgeStore<Id32>>,
-    R: Canon<BridgeStore<Id32>>,
-    Slf: Canon<BridgeStore<Id32>>,
+    S: Store,
+    A: Canon<S>,
+    R: Canon<S>,
+    Slf: Canon<S>,
 {
-    let bs = BridgeStore::<Id32>::default();
+    let bs = S::default();
     let wrapped = Transaction::from_canon(transaction, &bs)?;
     let (state, result) = transact_raw(&target, &wrapped)?;
 
-    *slf = state.cast(bs)?;
+    *slf = state.cast(bs.clone())?;
 
     result.cast(bs)
 }


### PR DESCRIPTION
Contracts might require the generic `S` (e.g. the [stack] ones), and in
that case the `Canon<BridgeStore<Id32>>` bound for `Self` in
`dusk_abi::transact` won't be satisfied. This patch fixes the problem
replacing `BridgeStore<Id32>` with the generic `S` for function.

Resolves: #19

[stack]: https://github.com/dusk-network/rusk-vm/tree/master/tests/contracts/stack