### PR TITLE
Fix inter-contract call transaction issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add `Self` to `transact_raw` to store intermediate state
+- Add `cast` method to `Transaction` type
+
+### Changed
+- Change buffer size from 2 KiB to 16 KiB
 - Replace `BridgeStore<Id32>` with generic `S` in `transact` [#19]
 
 ## [0.6.0] - 2021-03-01

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -9,7 +9,7 @@ extern crate alloc;
 use crate::canon_to_vec::CanonToVec;
 
 use alloc::vec::Vec;
-use canonical::{Canon, Store};
+use canonical::{ByteSource, Canon, Store};
 use canonical_derive::Canon;
 
 /// A generic transaction
@@ -34,5 +34,15 @@ impl Transaction {
         S: Store,
     {
         Ok(Transaction(c.encode_to_vec(s)?))
+    }
+
+    /// Casts the encoded transaction to given type(s)
+    pub fn cast<C, S>(&self, store: S) -> Result<C, S::Error>
+    where
+        C: Canon<S>,
+        S: Store,
+    {
+        let mut source = ByteSource::new(self.as_bytes(), &store);
+        Canon::<S>::read(&mut source)
     }
 }


### PR DESCRIPTION
> See dusk-network/rusk-vm#167 for tests that are using this branch

- Change buffer size from 2 KiB to 16 KiB
- Add `Self` to `transact_raw` to store intermediate state

Resolves: #22
See also: dusk-network/rusk#209


