### PR TITLE
Add gas_consumed host call interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `gas_consumed` host function interface [#24].
+
 ## [0.7.0] 2021-03-12
 
 ### Added
+
 - Add `Self` to `transact_raw` to store intermediate state
 - Add `cast` method to `Transaction` type
 
 ### Changed
+
 - Change buffer size from 2 KiB to 16 KiB
 - Replace `BridgeStore<Id32>` with generic `S` in `transact` [#19]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
   "Kristoffer Ström <kristoffer@dusk.network>",
   "zer0 <matteo@dusk.network>",
   "Jules de Smit <jules@dusk.network>",
-  "Cperezz <carlos@dusk.network>"
+  "CPerezz <carlos@dusk.network>"
 ]
 edition = "2018"
 

--- a/src/hosted.rs
+++ b/src/hosted.rs
@@ -63,7 +63,7 @@ pub fn gas(value: i32) {
 
 /// Return the ammount of gas consumed until the point when the host call is executed.
 pub fn gas_consumed() -> u64 {
-    unsafe { extertal::gas_consumed() }
+    unsafe { external::gas_consumed() }
 }
 
 /// Call another contract at address `target`

--- a/src/hosted.rs
+++ b/src/hosted.rs
@@ -32,6 +32,7 @@ pub mod external {
         pub fn callee(buffer: &mut u8);
 
         pub fn gas(value: i32);
+        pub fn gas_consumed() -> u64;
         pub fn block_height() -> u64;
     }
 }
@@ -58,6 +59,11 @@ pub fn block_height() -> u64 {
 /// Deduct a specified amount of gas from the call
 pub fn gas(value: i32) {
     unsafe { external::gas(value) }
+}
+
+/// Return the ammount of gas consumed until the point when the host call is executed.
+pub fn gas_consumed() -> u64 {
+    unsafe { extertal::gas_consumed() }
 }
 
 /// Call another contract at address `target`


### PR DESCRIPTION
As stated in #24 we need an interface in order to call the gas_consumed
host function inside of our contracts.

Resolves: #24