### PR TITLE
Gas Limit Parameter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-abi"
-version = "0.9.1"
+version = "0.10.0"
 authors = [
   "Kristoffer Ström <kristoffer@dusk.network>",
   "zer0 <matteo@dusk.network>",


### PR DESCRIPTION
This PR adds gas limit parameter to 'query', 'query_raw', 'transact', 'transact_raw' functions.
It also changes declaration of external "C" functions 'query' and 'transact' to have gas limit parameter.
This PR is needed for issue 254 of rusk-vm (Implement gas context for inter-contract calls).
As this is a breaking change, I increased version to 0.10.0 (from 0.9.1).