### PR TITLE
Add traits to `ContractId` to be used inside error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1] - 2022-02-23
+
+### Added
+
+- Add `Display`, `LowerHex` and `UpperHex` traits to `ContractId` [#39]
+
+### Changed
+
+- Change how `Debug` trait is implemented for `ContractId`
+
+## [0.10.0] - 2021-11-10
+
+### Added
+
+- Add parameter for gas limit
+
 ## [0.9.1] - 2021-07-15
 
 ### Added
@@ -189,6 +205,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Basic transaction framework
 
+[#39]: https://github.com/dusk-network/dusk-abi/issues/39
 [#31]: https://github.com/dusk-network/dusk-abi/issues/31
 [#28]: https://github.com/dusk-network/dusk-abi/issues/28
 [#19]: https://github.com/dusk-network/dusk-abi/issues/19

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-abi"
-version = "0.10.0"
+version = "0.10.1"
 authors = [
   "Kristoffer Ström <kristoffer@dusk.network>",
   "zer0 <matteo@dusk.network>",

--- a/src/types/contract.rs
+++ b/src/types/contract.rs
@@ -39,9 +39,7 @@ impl ContractState {
 }
 
 /// Type used to identify a contract
-#[derive(
-    Default, Debug, Hash, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Canon,
-)]
+#[derive(Default, Hash, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Canon)]
 pub struct ContractId([u8; 32]);
 
 impl<B> From<B> for ContractId
@@ -76,5 +74,70 @@ impl ContractId {
     /// Returns a `ContractId` from an array of 32 bytes
     pub const fn from_raw(b: [u8; 32]) -> Self {
         Self(b)
+    }
+}
+
+impl core::fmt::LowerHex for ContractId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let bytes = self.as_bytes();
+
+        if f.alternate() {
+            write!(f, "0x")?
+        }
+
+        for byte in bytes {
+            write!(f, "{:02x}", &byte)?
+        }
+
+        Ok(())
+    }
+}
+
+impl core::fmt::UpperHex for ContractId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let bytes = self.as_bytes();
+
+        if f.alternate() {
+            write!(f, "0x")?
+        }
+
+        for byte in bytes {
+            write!(f, "{:02X}", &byte)?
+        }
+
+        Ok(())
+    }
+}
+
+impl core::fmt::Display for ContractId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::LowerHex::fmt(self, f)
+    }
+}
+
+#[allow(non_snake_case)]
+impl core::fmt::Debug for ContractId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // Once we format an object using the debug notation (e.g. `{:x?}`)
+        // there is absolutely NO WAY to detect the flag for the lowerhex
+        // or upperhex, and therefore forwarding to the relevant formatter.
+        // Two methods for this purpose exists, but they're not exposed
+        // because they didn't agree on a name yet, see:
+        // <https://github.com/rust-lang/rust/blob/90442458ac46b1d5eed752c316da25450f67285b/library/core/src/fmt/mod.rs#L1817-L1825>
+        //
+        // Therefore the only way is using the deprecated method `flags`,
+        // implementing the same logic of the forementioned methods.
+
+        // We also do not have access to the `FlagV1` enum since it's
+        // private.
+        let FlagV1_DebugUpperHex = 5_u32;
+
+        #[allow(deprecated)]
+        if f.flags() & (1 << FlagV1_DebugUpperHex) != 0 {
+            core::fmt::UpperHex::fmt(self, f)
+        } else {
+            // LowerHex is always the default for debug
+            core::fmt::LowerHex::fmt(self, f)
+        }
     }
 }


### PR DESCRIPTION
- Add `Display`, `LowerHex` and `UpperHex` traits to `ContractId`
- Change how `Debug` trait is implemented for `ContractId`
- Update CHANGELOG.md
- Bump to `v0.10.1`

See also: dusk-network/rusk-vm#301
Resolves #39